### PR TITLE
Fix/repo missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 因 UR 官方僅有 Ubuntu 虛擬機之離線編譯環境，並未提供 Windows 的離線編譯工具，故建立此 VSCode 套件來提供額外的程式撰寫環境
 
-
 ## 提醒
 
 - 此套件 **不包含** 編譯、語法檢查，程式撰寫完畢後仍需傳入控制器或虛擬機進行檢查！
@@ -17,17 +16,29 @@
 
 - 自動完成項目
   - 以官方 scriptManual.pdf 所產生對應的方法說明
-  ![completion](resources/figures/completion.png)
-	
+    ![completion](resources/figures/completion.png)
 - 滑鼠停留時的方法提示
+
   - 目前僅能提供 UR Script 方法的提示，自訂的方法( `def` )尚不能顯示提示
-  ![hover](resources/figures/hover_tip.png)
-  
+    ![hover](resources/figures/hover_tip.png)
+
 - 程式碼區塊
   - 提供如 def、if、while 等語法可以快速建立，持續新增中
-  ![snippet](resources/figures/snippets.png)
+    ![snippet](resources/figures/snippets.png)
 
 ## 版本紀錄
 
 ### 0.0.0 (dev)
-  - CompletionItems、SignatureHelp、Hover、Snippets
+
+- CompletionItems、SignatureHelp、Hover、Snippets
+
+## INSTALLATION INSTRUCTIONS
+
+To install the extension we need to compile it into the VSIX code and then side load it into VSCode.
+
+1.  `npm install -g vsce` to make sure you have vsce installed globally
+2.  `git clone https://github.com/ahernguo/urscript-extension` to clone the repo if you havent already done so
+3.  `cd urscript-extension`
+4.  `npm install` to install dependencies if you havent already done so
+5.  `vsce package` to build the package. This will generate a file with extension vsix
+6.  Open VSCode and Run the command Extensions: Install from VSIX..., choose the vsix file generated in the previous step

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Hirebotics/urscript-extension.git"
+    "url": "git+https://github.com/ahernguo/urscript-extension.git"
   },
   "main": "./out/extension",
   "contributes": {

--- a/package.json
+++ b/package.json
@@ -1,61 +1,65 @@
 {
-    "name": "urscript",
-    "displayName": "URScript",
-    "description": "Code snippet and completion items for Universal Robots Script",
-    "version": "0.0.1",
-    "publisher": "Ahern",
-    "engines": {
-        "vscode": "^1.37.0"
-    },
-    "categories": [
-        "Programming Languages",
-        "Snippets",
-        "Other"
-    ],
-    "activationEvents": [
-        "onLanguage:urscript"
-    ],
-    "main": "./out/extension",
-    "contributes": {
-        "languages": [
-            {
-                "id": "urscript",
-                "aliases": [
-                    "URScript",
-                    "script"
-                ],
-                "extensions": [
-                    ".script"
-                ],
-                "configuration": "./language-configuration.json"
-            }
+  "name": "urscript",
+  "displayName": "URScript",
+  "description": "Code snippet and completion items for Universal Robots Script",
+  "version": "0.0.1",
+  "publisher": "Ahern",
+  "engines": {
+    "vscode": "^1.37.0"
+  },
+  "categories": [
+    "Programming Languages",
+    "Snippets",
+    "Other"
+  ],
+  "activationEvents": [
+    "onLanguage:urscript"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Hirebotics/urscript-extension.git"
+  },
+  "main": "./out/extension",
+  "contributes": {
+    "languages": [
+      {
+        "id": "urscript",
+        "aliases": [
+          "URScript",
+          "script"
         ],
-        "snippets": [
-            {
-                "language": "urscript",
-                "path": "./snippets/urscript.json"
-            }
+        "extensions": [
+          ".script"
         ],
-        "grammars": [
-            {
-                "language": "urscript",
-                "scopeName": "source.urscript",
-                "path": "./syntaxes/urscript.tmLanguage.json"
-            }
-        ]
-    },
-    "scripts": {
-        "vscode:prepublish": "npm run compile",
-        "compile": "tsc -p ./",
-        "watch": "tsc -watch -p ./",
-        "postinstall": "node ./node_modules/vscode/bin/install",
-        "test": "npm run compile && node ./node_modules/vscode/bin/test"
-    },
-    "devDependencies": {
-        "typescript": "^2.6.1",
-        "vscode": "^1.1.21",
-        "tslint": "^5.8.0",
-        "@types/node": "^8.10.25",
-        "@types/mocha": "^2.2.42"
-    }
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "snippets": [
+      {
+        "language": "urscript",
+        "path": "./snippets/urscript.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "urscript",
+        "scopeName": "source.urscript",
+        "path": "./syntaxes/urscript.tmLanguage.json"
+      }
+    ]
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "postinstall": "node ./node_modules/vscode/bin/install",
+    "test": "npm run compile && node ./node_modules/vscode/bin/test"
+  },
+  "devDependencies": {
+    "typescript": "^2.6.1",
+    "vscode": "^1.1.21",
+    "tslint": "^5.8.0",
+    "@types/node": "^8.10.25",
+    "@types/mocha": "^2.2.42"
+  }
 }


### PR DESCRIPTION
When we tried to build the extension for VSCode we ran into an issue where the repo was missing from package.json and so the extension could not be built since the images in the README could not be found.  Added the repo to package.json.

Updated README to have instructions for side-loading an extension into VSCODE since the code has to be built and then loaded, cannot follow standard procedure of adding extension from the extension store