### PR TITLE
Initial support for upcoming struct type

### DIFF
--- a/src/features/completionItemProvider.ts
+++ b/src/features/completionItemProvider.ts
@@ -120,10 +120,10 @@ export class URScriptCompletionItemProvider implements CompletionItemProvider {
                                         if (/=.+/.test(p)) {
                                             const pnReg = /.*(?==)/.exec(p);
                                             if (pnReg) {
-                                                return `# @param ${pnReg[0].trim()} \${${index++}|bool,int,float,number,array,pose,string|} \${${index++}:${pnReg[0].trim()}}`;
+                                                return `# @param ${pnReg[0].trim()} \${${index++}|bool,int,float,number,array,pose,string,struct|} \${${index++}:${pnReg[0].trim()}}`;
                                             }
                                         } else {
-                                            return `# @param ${p.trim()} \${${index++}|bool,int,float,number,array,pose,string|} \${${index++}:${p.trim()}}`;
+                                            return `# @param ${p.trim()} \${${index++}|bool,int,float,number,array,pose,string,struct|} \${${index++}:${p.trim()}}`;
                                         }
                                     }
                                 );
@@ -158,7 +158,7 @@ export class URScriptCompletionItemProvider implements CompletionItemProvider {
                     '@param `name` `type` your comments'
                 );
                 paramCmpItem.insertText = new SnippetString(
-                    '# @param ${1:name} ${2|bool,int,float,number,array,pose,string|} ${0:comments}'
+                    '# @param ${1:name} ${2|bool,int,float,number,array,pose,string,struct|} ${0:comments}'
                 );
                 /* add @returns */
                 const returnCmpItem = new CompletionItem('@returns', CompletionItemKind.Snippet);
@@ -171,7 +171,7 @@ export class URScriptCompletionItemProvider implements CompletionItemProvider {
                     '@returns `type` your comments'
                 );
                 returnCmpItem.insertText = new SnippetString(
-                    '# @returns ${1|void,bool,int,float,number,array,pose,string|} ${0:comments}'
+                    '# @returns ${1|void,bool,int,float,number,array,pose,string,struct|} ${0:comments}'
                 );
                 /* return parts of UrDoc of CompletionItem */
                 return new CompletionList([paramCmpItem, returnCmpItem], false);

--- a/src/scriptmethod.ts
+++ b/src/scriptmethod.ts
@@ -40,7 +40,11 @@ export enum Types {
     /**
      * string
      */
-    String = 0x12
+    String = 0x12,
+    /**
+     * struct
+     */
+    Struct = 0x30
 }
 
 /**
@@ -57,6 +61,7 @@ export function type2Str(value: Types): string {
         case Types.Number: return 'number';
         case Types.Pose: return 'pose';
         case Types.String: return 'string';
+        case Types.Struct: return 'struct';
         default: return 'void';
     }
 }
@@ -77,6 +82,7 @@ export function str2Type(str: string | undefined): Types {
             case 'number': return Types.Number;
             case 'pose': return Types.Pose;
             case 'string': return Types.String;
+            case 'struct': return Types.Struct;
             default: return Types.None;
         }
     } else {

--- a/syntaxes/urscript.tmLanguage.json
+++ b/syntaxes/urscript.tmLanguage.json
@@ -72,7 +72,7 @@
                         {
                             "name": "comment.block.documentation.urscript",
                             "begin": "(@param)\\s+(\\w+)",
-                            "end": "(none|void|bool|number|int|float|array|pose|string)",
+                            "end": "(none|void|bool|number|int|float|array|pose|string|struct)",
                             "beginCaptures": {
                                 "1": {
                                     "name": "entity.name.tag.urscript"
@@ -90,7 +90,7 @@
                         {
                             "name": "comment.block.documentation.urscript",
                             "begin": "(@returns)",
-                            "end": "(none|void|bool|number|int|float|array|pose|string)",
+                            "end": "(none|void|bool|number|int|float|array|pose|string|struct)",
                             "beginCaptures": {
                                 "1": {
                                     "name": "entity.name.tag.urscript"
@@ -198,7 +198,7 @@
             "patterns": [
                 {
                     "name": "support.other.urscript",
-                    "begin": "^(void|bool|int|float|number|array|pose|string)\\s",
+                    "begin": "^(void|bool|int|float|number|array|pose|string|struct)\\s",
                     "end": "$",
                     "beginCaptures": {
                         "1": {
@@ -208,7 +208,7 @@
                     "patterns": [
                         {
                             "name": "entity.name.type.urscript",
-                            "match": "(none|void|bool|number|int|float|array|pose|string)"
+                            "match": "(none|void|bool|number|int|float|array|pose|string|struct)"
                         },
                         {
                             "name": "entity.name.function.urscript",


### PR DESCRIPTION
The next version of URScript would feature a new type `struct`. Presence of this keyword in doxygen comments was causing issues with the formatting and syntax coloring. This PR fixes that. More updates may be needed beyond this in future to fully support the  new `struct` type.